### PR TITLE
QA-147 #comment Ticket backend now requires no 'Z' at the end of showing date

### DIFF
--- a/src/main/java/com/qa/cinema/service/DBTicketService.java
+++ b/src/main/java/com/qa/cinema/service/DBTicketService.java
@@ -186,7 +186,6 @@ public class DBTicketService implements TicketService {
 		int tIndex = strShowingDate.indexOf("T");
 		strShowingDate.replace(tIndex, tIndex+1, " ");
 		
-		strShowingDate.deleteCharAt(strShowingDate.indexOf("Z"));
 		
 		try {
 			showingDate = (Date) formatter.parse(strShowingDate.toString());


### PR DESCRIPTION
- [ ] code
- [ ] test
- [ ] review